### PR TITLE
Add "fill bucket" functionality

### DIFF
--- a/src/aiolimiter/leakybucket.py
+++ b/src/aiolimiter/leakybucket.py
@@ -35,7 +35,12 @@ class AsyncLimiter(AbstractAsyncContextManager):
     max_rate: float  #: The configured `max_rate` value for this limiter.
     time_period: float  #: The configured `time_period` value for this limiter.
 
-    def __init__(self, max_rate: float, time_period: float = 60, start_filled: bool = False) -> None:
+    def __init__(
+        self,
+        max_rate: float,
+        time_period: float = 60,
+        start_filled: bool = False
+    ) -> None:
         self.max_rate = max_rate
         self.time_period = time_period
         self._rate_per_sec = max_rate / time_period
@@ -75,7 +80,7 @@ class AsyncLimiter(AbstractAsyncContextManager):
                     fut.set_result(True)
                     break
         return self._level + amount <= self.max_rate
-    
+
     def fill(self) -> None:
         """Fill the bucket."""
         loop = asyncio.get_running_loop()

--- a/src/aiolimiter/leakybucket.py
+++ b/src/aiolimiter/leakybucket.py
@@ -27,7 +27,8 @@ class AsyncLimiter(AbstractAsyncContextManager):
     :param time_period: duration, in seconds, of the time period in which to
        limit the rate. Note that up to `max_rate` acquisitions are allowed
        within this time period in a burst.
-    :param start_filled: Whether to start with the bucket "full".
+    :param start_filled: Whether to start with the bucket "full"; setting to
+        `True` will prevent a "burst" at the beginning.
 
     """
 

--- a/tests/test_aiolimiter.py
+++ b/tests/test_aiolimiter.py
@@ -59,6 +59,17 @@ async def test_has_capacity():
     assert not limiter.has_capacity()
 
 
+async def test_fill():
+    limiter = AsyncLimiter(1)
+    limiter.fill()
+    assert not limiter.has_capacity()
+
+
+async def test_start_filled():
+    limiter = AsyncLimiter(1, start_filled=True)
+    assert not limiter.has_capacity()
+
+
 async def test_over_acquire():
     limiter = AsyncLimiter(1)
     with pytest.raises(ValueError):


### PR DESCRIPTION
Since the bucket starts empty, a there's a burst of acquisitions at the beginning, followed by a steady stream as drops leak out of the bucket. For example, if you have an API with a rate limit of 1000 requests per minute, and you created a rate limiter with `AsyncLimiter(1000)`, normal usage would mean:
1. 1000 request are sent immediately, filling up the bucket
2. Drops begin to leak out of the bucket
3. Another request is sent once capacity is available
This leads to more than 1000 requests being sent in a minute, and cause the API to shout at you :(

I figured I might as well add the feature properly rather than monkey-patching it myself in every use-case; this PR adds:
- A `fill()` method to `AsyncLimiter`
- A `start_filled` parameter to `AsyncLimiter.__init__()`
- Couple of small tests for the above