### PR TITLE
correct with to async with in docs index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,7 +44,7 @@ then use this object as an :ref:`asynchronous context manager
 <async-context-managers>`, so with :keyword:`async with`, to enclose a section
 you want to control the rate of execution of::
 
-    with limiter:
+    async with limiter:
         # this section will, at most, be entered 100 times / minute
 
 You can also call the :meth:`AsyncLimiter.acquire` async method directly::


### PR DESCRIPTION
I might be wrong, but it looks like the docs here have `with` where `async with` is meant.

Apologies if I'm off base here, I'm not (yet) actually a user of `aiolimiter`, was just looking at the docs and though I spotted an issue worth pointing out.

I think `async with` is meant since:

1. It mentions asynchronous context managers above and `async with` explicitly
3. The package implements [`AsyncLimiter.__aenter__`](https://github.com/mjpieters/aiolimiter/blob/e997a65c1ab61717b14740794f35b63420e7d4c4/src/aiolimiter/leakybucket.py#L110) and [`AsyncLimiter.__aexit__`](https://github.com/mjpieters/aiolimiter/blob/e997a65c1ab61717b14740794f35b63420e7d4c4/src/aiolimiter/leakybucket.py#L114) but not `AsyncLimiter.__enter__` or `AsyncLimiter.__exit__` so I think `AsyncLimiter` will be valid only for `async with` and not plain `with`
4.  `AsyncLimiter` inherits from `AbstractAsyncContextManager`
5. The [bursting section](https://github.com/mjpieters/aiolimiter/blob/master/docs/index.rst#bursting) uses `async with`
6. The [`AsyncLimiter` docstring uses `async with`](https://github.com/mjpieters/aiolimiter/blob/e997a65c1ab61717b14740794f35b63420e7d4c4/src/aiolimiter/leakybucket.py#L22)