### PR TITLE
Add `__slots__` to `AsyncLimiter`

### DIFF
--- a/changelog.d/85.feature
+++ b/changelog.d/85.feature
@@ -1,1 +1,1 @@
-Add ``__slots__`` to the ``AsyncLimiter`` class.
+Add ``__slots__`` to the ``AsyncLimiter`` class, reducing memory requirements.

--- a/changelog.d/85.feature
+++ b/changelog.d/85.feature
@@ -1,0 +1,1 @@
+Add ``__slots__`` to the ``AsyncLimiter`` class.

--- a/src/aiolimiter/leakybucket.py
+++ b/src/aiolimiter/leakybucket.py
@@ -29,9 +29,15 @@ class AsyncLimiter(AbstractAsyncContextManager):
        within this time period in a burst.
 
     """
-    
-    __slots__ = ("max_rate", "time_period", "_rate_per_sec", "_level", 
-                 "_last_check", "_waiters")
+
+    __slots__ = (
+        "max_rate",
+        "time_period",
+        "_rate_per_sec",
+        "_level",
+        "_last_check",
+        "_waiters",
+    )
 
     max_rate: float  #: The configured `max_rate` value for this limiter.
     time_period: float  #: The configured `time_period` value for this limiter.

--- a/src/aiolimiter/leakybucket.py
+++ b/src/aiolimiter/leakybucket.py
@@ -29,6 +29,9 @@ class AsyncLimiter(AbstractAsyncContextManager):
        within this time period in a burst.
 
     """
+    
+    __slots__ = ("max_rate", "time_period", "_rate_per_sec", "_level", 
+                 "_last_check", "_waiters")
 
     max_rate: float  #: The configured `max_rate` value for this limiter.
     time_period: float  #: The configured `time_period` value for this limiter.


### PR DESCRIPTION
Adding `__slots__` reduces memory usage (important here since one can have many AsyncLimiter instances) and speeds up attribute access. See [here](https://stackoverflow.com/questions/472000/usage-of-slots) to learn more