### PR TITLE
CI: Unbreak linting

### DIFF
--- a/.azure-pipelines/stage-lint.yml
+++ b/.azure-pipelines/stage-lint.yml
@@ -97,7 +97,9 @@ stages:
           - bash: poetry install -E docs
             displayName: Install dependencies
 
-          - bash: poetry run doit -v2 docs
+          - bash: |
+              poetry run doit ignore _poetry_install  # don't uninstall the docs extra
+              poetry run doit -v2 docs
             displayName: "Run docs checker"
 
       - job: "twine"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 minimum_pre_commit_version: 1.14.0
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 22.10.0
     hooks:
       - id: black
         language_version: python3.7

--- a/changelog.d/95.misc
+++ b/changelog.d/95.misc
@@ -1,0 +1,2 @@
+Updated the version of black in the CI and pre-commit, and adjusted CI steps to
+account for recent versions of poetry.

--- a/dodo.py
+++ b/dodo.py
@@ -83,10 +83,9 @@ def with_poetry(*actions):
 def task_poetry_install():
     # in case we have doit installed outside of poetry
     # and there is no lock file, run poetry first.
-    extras = ["--extras", "docs"] if not ON_CI else []
     return {
         "basename": "_install_poetry",
-        "actions": [["poetry", "install", *extras]],
+        "actions": [["poetry", "install", "--extras", "docs"]],
         "targets": ["poetry.lock"],
         "uptodate": [run_once],
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ twine = "^4.0.0"
 towncrier = "^22.8.0"
 
 [tool.poetry.dev-dependencies.black]
-version = "^20.8b0"
+version = "^22.10.0"
 markers = "platform_python_implementation != 'PyPy'"
 
 [tool.poetry.dev-dependencies.mypy]


### PR DESCRIPTION
The doit command would trigger _poetry_install, which runs poetry
without the `-E docs` extra. Recent poetry versions now uninstall everything
related to the extras not explicitly listed, breaking any docs linting
steps. Explicitly ignoring the task is easiest.

At the same time, upgrade black to a version that doesn't break rely on
private internals of click that have since been removed.
