### PR TITLE
ci: Update the python version used by RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ build:
   image: latest
 
 python:
-  version: 3.7
+  version: 3.11
   install:
     - method: pip
       path: .


### PR DESCRIPTION
3.7 is too old to build the docs now; bump to 3.11 for maximum runway length.
