### PR TITLE
ci: fix RTD config for new Python versions

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,10 +1,11 @@
 version: 2
 
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: '3.11'
 
 python:
-  version: 3.11
   install:
     - method: pip
       path: .


### PR DESCRIPTION
The python.version key is deprecated and doesn't support versions newer than 3.8.
