### PR TITLE
ci: Use Poetry in RTD build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,10 +4,12 @@ build:
   os: ubuntu-22.04
   tools:
     python: '3.11'
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+  jobs:
+    # https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-poetry
+    # this is needed because we no longer list docs as an extra, but rather as a
+    # poetry dependency group.
+    post_create_environment:
+      - pip install poetry
+      - poetry config virtualenvs.create false
+    post_install:
+      - poetry install --no-interaction --with docs


### PR DESCRIPTION
This allows us to install the docs dependency group; we no longer use extras to install the documentation dependencies.
