### PR TITLE
Refactor how waiting tasks are handled

### DIFF
--- a/changelog.d/73.bugfix.md
+++ b/changelog.d/73.bugfix.md
@@ -1,0 +1,3 @@
+Improve performance by using a single timeout and a heapq for blocked tasks.
+This ensures only a single task needs to wake up per 'drip' of the bucket,
+instead of creating timeouts for every task.

--- a/src/aiolimiter/leakybucket.py
+++ b/src/aiolimiter/leakybucket.py
@@ -4,8 +4,11 @@
 
 import asyncio
 from contextlib import AbstractAsyncContextManager
+from functools import partial
+from heapq import heappop, heappush
+from itertools import count
 from types import TracebackType
-from typing import Dict, Optional, Type
+from typing import List, Optional, Tuple, Type
 
 
 class AsyncLimiter(AbstractAsyncContextManager):
@@ -34,7 +37,10 @@ class AsyncLimiter(AbstractAsyncContextManager):
         "_rate_per_sec",
         "_level",
         "_last_check",
+        "_event_loop",
         "_waiters",
+        "_next_count",
+        "_waker_handle",
     )
 
     max_rate: float  #: The configured `max_rate` value for this limiter.
@@ -46,19 +52,33 @@ class AsyncLimiter(AbstractAsyncContextManager):
         self._rate_per_sec = max_rate / time_period
         self._level = 0.0
         self._last_check = 0.0
-        # queue of waiting futures to signal capacity to
-        self._waiters: Dict[asyncio.Task, asyncio.Future] = {}
+
+        # timer until next waiter can resume
+        self._waker_handle: asyncio.TimerHandle | None = None
+        # min-heap with (amount requested, order, future) for waiting tasks
+        self._waiters: List[Tuple[float, int, "asyncio.Future[None]"]] = []
+        # counter used to order waiting tasks
+        self._next_count = partial(next, count())
+
+    @property
+    def _loop(self) -> asyncio.AbstractEventLoop:
+        self._event_loop: asyncio.AbstractEventLoop
+        try:
+            loop = self._event_loop
+        except AttributeError:
+            loop = self._event_loop = asyncio.get_running_loop()
+        return loop
 
     def _leak(self) -> None:
         """Drip out capacity from the bucket."""
-        loop = asyncio.get_running_loop()
+        now = self._loop.time()
         if self._level:
             # drip out enough level for the elapsed time since
             # we last checked
-            elapsed = loop.time() - self._last_check
+            elapsed = now - self._last_check
             decrement = elapsed * self._rate_per_sec
             self._level = max(self._level - decrement, 0)
-        self._last_check = loop.time()
+        self._last_check = now
 
     def has_capacity(self, amount: float = 1) -> bool:
         """Check if there is enough capacity remaining in the limiter
@@ -67,15 +87,6 @@ class AsyncLimiter(AbstractAsyncContextManager):
 
         """
         self._leak()
-        requested = self._level + amount
-        # if there are tasks waiting for capacity, signal to the first
-        # there there may be some now (they won't wake up until this task
-        # yields with an await)
-        if requested < self.max_rate:
-            for fut in self._waiters.values():
-                if not fut.done():
-                    fut.set_result(True)
-                    break
         return self._level + amount <= self.max_rate
 
     async def acquire(self, amount: float = 1) -> None:
@@ -92,31 +103,56 @@ class AsyncLimiter(AbstractAsyncContextManager):
         if amount > self.max_rate:
             raise ValueError("Can't acquire more than the maximum capacity")
 
-        loop = asyncio.get_running_loop()
-        task = asyncio.current_task(loop)
-        assert task is not None
+        loop = self._loop
         while not self.has_capacity(amount):
-            # wait for the next drip to have left the bucket
-            # add a future to the _waiters map to be notified
-            # 'early' if capacity has come up
+            # Add a future to the _waiters heapq to be notified when capacity
+            # has come up. The future callback uses call_soon so other tasks
+            # are checked *after* completing capacity acquisition in this task.
             fut = loop.create_future()
-            self._waiters[task] = fut
-            try:
-                # we need to wait until current_capacity is equal or greater than the
-                # requested amount, where current_capacity is
-                # (self.max_rate - self._level)
-                wait_time = (
-                    1 / self._rate_per_sec * (amount - self.max_rate + self._level)
-                )
-                await asyncio.wait_for(asyncio.shield(fut), wait_time)
-            except asyncio.TimeoutError:
-                pass
-            fut.cancel()
-        self._waiters.pop(task, None)
+            fut.add_done_callback(partial(loop.call_soon, self._wake_next))
+            heappush(self._waiters, (amount, self._next_count(), fut))
+            self._wake_next()
+            await fut
 
         self._level += amount
+        # reset the waker to account for the new, lower level.
+        self._wake_next()
 
         return None
+
+    def _wake_next(self, *_args: object) -> None:
+        """Wake the next waiting future or set a timer"""
+        # clear timer and any cancelled futures at the top of the heap
+        heap, handle, self._waker_handle = self._waiters, self._waker_handle, None
+        if handle is not None:
+            handle.cancel()
+        while heap and heap[0][-1].done():
+            heappop(heap)
+
+        if not heap:
+            # nothing left waiting
+            return
+
+        amount, _, fut = heap[0]
+        self._leak()
+        needed = amount - self.max_rate + self._level
+        if needed <= 0:
+            heappop(heap)
+            fut.set_result(None)
+            # fut.set_result triggers another _wake_next call
+            return
+
+        wake_next_at = self._last_check + (1 / self._rate_per_sec * needed)
+        self._waker_handle = self._loop.call_at(wake_next_at, self._wake_next)
+
+    def __repr__(self) -> str:  # pragma: no cover
+        args = f"max_rate={self.max_rate!r}, time_period={self.time_period!r}"
+        state = f"level: {self._level:f}, waiters: {len(self._waiters)}"
+        if (handle := self._waker_handle) and not handle.cancelled():
+            microseconds = int((handle.when() - self._loop.time()) * 10**6)
+            if microseconds > 0:
+                state += f", waking in {microseconds} \N{MICRO SIGN}s"
+        return f"<AsyncLimiter({args}) at {id(self):#x} [{state}]>"
 
     async def __aenter__(self) -> None:
         await self.acquire()


### PR DESCRIPTION
Instead of creating a timeout per waiting task, create a single timeout that wakes up the next lowest-amount-requested task in a min-heap of waiting tasks.

This significantly reduces the overhead burden on the event loop when there are a large number of tasks blocked by limiters.

Fixes #73
