### PR TITLE
Include tests in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 
 include = [
     { path = "CHANGELOG.md", format = "sdist" },
+    { path = "tests", format = "sdist" },
 ]
 
 [tool.poetry.urls]


### PR DESCRIPTION
As of now tests are not included in the sdist package making it hard for distro maintainers to properly test this project in the packages. At least Debian uses sdist package [1]

[1] https://sources.debian.org/src/aiolimiter/1.2.1-1.1/debian/watch/