### PR TITLE
ci: use gh cli to create releases

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -230,10 +230,6 @@ jobs:
       contents: write  # required for creating GH releases
 
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        persist-credentials: false
-
     - name: Download Python 🐍 distribution 📦
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
@@ -243,9 +239,9 @@ jobs:
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
 
     - name: GitHub release
-      uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1.20.0
-      with:
-        name: Aiolimiter ${{ needs.build.outputs.version }}
-        bodyFile: release_notes.md
-        artifacts: dist/*
-        prerelease: ${{ needs.build.outputs.prerelease }}
+      env:
+        RELEASE_TITLE: Aiolimiter ${{ needs.build.outputs.version }}
+        PRERELEASE_SWITCH: ${{ case(fromJSON(needs.build.outputs.prerelease), '--prerelease', '') }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+      run: gh release create --title "${RELEASE_TITLE}" --notes-file release_notes.md "${PRERELEASE_SWITCH}" "${GITHUB_REF_NAME}" dist/*


### PR DESCRIPTION
We also don't need a checkout in this job.
