### PR TITLE
ci: Use standard GHA syntax to test matrix outcome

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,9 +44,7 @@
       "description": "These packages are not abandoned just yet",
       "matchPackageNames": [
         "aio-libs/get-releasenote",
-        "Lucas-C/pre-commit-hooks",
-        "toml",
-        "re-actors/alls-green"
+        "toml"
       ],
       "abandonmentThreshold": "5 years"
     }

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -148,10 +148,11 @@ jobs:
     if: always()
     steps:
     - name: Decide whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
-      with:
-        jobs: ${{ toJSON(needs) }}
-
+      env:
+        SUCCEEDED: ${{ !(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')) }}
+      run: |
+        echo "All jobs passed: ${SUCCEEDED}"
+        if [ "${SUCCEEDED}" = 'false' ]; then exit 1; fi
 
   build:
     name: Build distribution 📦


### PR DESCRIPTION
Update renovate configuration to remove no-longer 'outdated' packages
