### PR TITLE
chore: Update license years in headers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,7 @@ repos:
       - id: insert-license
         groups: [ci]
         args:
+          - --use-current-year
           - --license-filepath
           - .license_header.txt
         types_or:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
-# Copyright (c) 2019 Martijn Pieters
+# Copyright (c) 2019-2026 Martijn Pieters
 # Licensed under the MIT license as detailed in LICENSE.txt
 
 #

--- a/src/aiolimiter/__init__.py
+++ b/src/aiolimiter/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# Copyright (c) 2019 Martijn Pieters
+# Copyright (c) 2019-2025 Martijn Pieters
 # Licensed under the MIT license as detailed in LICENSE.txt
 
 from importlib.metadata import version

--- a/src/aiolimiter/leakybucket.py
+++ b/src/aiolimiter/leakybucket.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# Copyright (c) 2019 Martijn Pieters
+# Copyright (c) 2019-2026 Martijn Pieters
 # Licensed under the MIT license as detailed in LICENSE.txt
 
 from __future__ import annotations

--- a/tests/test_aiolimiter.py
+++ b/tests/test_aiolimiter.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# Copyright (c) 2019 Martijn Pieters
+# Copyright (c) 2019-2026 Martijn Pieters
 # Licensed under the MIT license as detailed in LICENSE.txt
 
 import asyncio


### PR DESCRIPTION
The years reflect the range of time in which the files were modified.  The `insert-license` git hook has been updated to maintain the ranges now at commit time.

We don't want the hook to re-adjust these files, so [skip prek] applies.
