### PR TITLE
chore: correct prek run command for renovate lint

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -54,7 +54,7 @@ tasks:
     deps:
       - dev:install-prek
     cmds:
-      - uv run prek run --files .github/renovate.json renovate-config-validator
+      - uv run prek run renovate-config-validator --files .github/renovate.json
 
   dev:lint:code:
     desc: Lint the source code


### PR DESCRIPTION
The `--files` argument goes after the hook id, otherwise the hook is assumed to be a file instead of a hook.
