### PR TITLE
ci: simplify uv setup

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -79,9 +79,7 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
-      with:
-        enable-cache: | # zizmor: ignore[cache-poisoning] cache is disabled when publishing to prevent poisoning
-          ${{ github.ref_type == 'tag' && 'false' || 'auto' }}
+      with:  # zizmor: ignore[cache-poisoning] on tag pushes, cache is automatically disabled by the action
         cache-dependency-glob: "uv.lock"
 
     - name: Install dependencies
@@ -125,9 +123,7 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
-      with:
-        enable-cache: | # zizmor: ignore[cache-poisoning] cache is disabled when publishing to prevent poisoning
-          ${{ github.ref_type == 'tag' && 'false' || 'auto' }}
+      with:  # zizmor: ignore[cache-poisoning] on tag pushes, cache is automatically disabled by the action
         cache-dependency-glob: "uv.lock"
         python-version: ${{ steps.python.outputs.python-path }}
         activate-environment: true
@@ -200,9 +196,7 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
-      with:
-        enable-cache: | # zizmor: ignore[cache-poisoning] cache is disabled when publishing to prevent poisoning
-          ${{ github.ref_type == 'tag' && 'false' || 'auto' }}
+      with:  # zizmor: ignore[cache-poisoning] on tag pushes, cache is automatically disabled by the action
         cache-dependency-glob: "uv.lock"
         python-version: ${{ steps.python.outputs.python-path }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,13 @@ default-groups = [
     "dev",
     "docs",
 ]
+# Ensure that uv rebuilds the project when git commit or tags change
+# to update the version
+cache-keys = [
+    { file = "pyproject.toml" },
+    { git = { commit = true, tags = true } },
+    { env = "UV_DYNAMIC_VERSIONING_BYPASS" }
+]
 
 [tool.hatch.build.targets.sdist]
 include = [


### PR DESCRIPTION
astral-sh/setup-up v10 no longer caches on tag pushes so we don't have to explicitly tell it not to ourselves.

While here, also configure uv to rebuild the project when the git reference changes.
