### PR TITLE
Reject negative and NaN acquisition amounts

### DIFF
--- a/changelog.d/760.feature.md
+++ b/changelog.d/760.feature.md
@@ -1,1 +1,1 @@
-Reject negative and NaN capacity amounts in AsyncLimiter.acquire() with ValueError, alongside amounts above the maximum capacity.
+Tightened boundary checks for the `amount` argument to `AsyncLimiter.acquire()`, rejecting values outside the 0 to `max_rate` range. Negative values and `NaN` are no longer accepted.

--- a/changelog.d/760.feature.md
+++ b/changelog.d/760.feature.md
@@ -1,0 +1,1 @@
+Reject negative and NaN capacity amounts in AsyncLimiter.acquire() with ValueError, alongside amounts above the maximum capacity.

--- a/src/aiolimiter/leakybucket.py
+++ b/src/aiolimiter/leakybucket.py
@@ -133,12 +133,14 @@ class AsyncLimiter(AbstractAsyncContextManager[None]):
         freed before returning.
 
         :param amount: How much capacity you need to be available.
-        :exception: Raises :exc:`ValueError` if `amount` is greater than
-           :attr:`max_rate`.
+        :exception: Raises :exc:`ValueError` if `amount` is negative, NaN,
+           or greater than :attr:`max_rate`.
 
         """
         if amount > self.max_rate:
             raise ValueError("Can't acquire more than the maximum capacity")
+        if not amount >= 0:
+            raise ValueError("Amount must be non-negative and not NaN")
 
         loop = self._loop
         while not self.has_capacity(amount):

--- a/src/aiolimiter/leakybucket.py
+++ b/src/aiolimiter/leakybucket.py
@@ -133,14 +133,14 @@ class AsyncLimiter(AbstractAsyncContextManager[None]):
         freed before returning.
 
         :param amount: How much capacity you need to be available.
-        :exception: Raises :exc:`ValueError` if `amount` is negative, NaN,
-           or greater than :attr:`max_rate`.
+        :exception: Raises :exc:`ValueError` if `amount` is not a number
+           between zero and :attr:`max_rate`, inclusive.
 
         """
-        if amount > self.max_rate:
-            raise ValueError("Can't acquire more than the maximum capacity")
-        if not amount >= 0:
-            raise ValueError("Amount must be non-negative and not NaN")
+        if not 0 <= amount <= self.max_rate:
+            raise ValueError(
+                "Amount must be a number between 0 and the maximum capacity"
+            )
 
         loop = self._loop
         while not self.has_capacity(amount):

--- a/tests/test_aiolimiter.py
+++ b/tests/test_aiolimiter.py
@@ -54,6 +54,25 @@ async def test_over_acquire() -> None:
         await limiter.acquire(42)
 
 
+@pytest.mark.parametrize("amount", [-1, float("-inf"), float("nan")])
+async def test_invalid_acquire_preserves_capacity(amount: float) -> None:
+    limiter = AsyncLimiter(1)
+    await limiter.acquire()
+    with pytest.raises(ValueError):
+        await asyncio.wait_for(limiter.acquire(amount), timeout=0.1)
+    assert not limiter.has_capacity()
+
+
+async def test_acquire_zero_and_fractional_amounts() -> None:
+    limiter = AsyncLimiter(1)
+    with MockLoopTime():
+        await limiter.acquire(0)
+        assert limiter.has_capacity(1)
+        await limiter.acquire(0.5)
+        assert limiter.has_capacity(0.5)
+        assert not limiter.has_capacity(1)
+
+
 async def acquire_task(limiter: AsyncLimiter) -> None:
     await limiter.acquire()
 

--- a/tests/test_aiolimiter.py
+++ b/tests/test_aiolimiter.py
@@ -48,29 +48,11 @@ async def test_has_capacity() -> None:
     assert not limiter.has_capacity()
 
 
-async def test_over_acquire() -> None:
+@pytest.mark.parametrize("amount", [-1, float("-inf"), float("nan"), 42])
+async def test_acquire_boundary_checks(amount: float) -> None:
     limiter = AsyncLimiter(1)
     with pytest.raises(ValueError):
-        await limiter.acquire(42)
-
-
-@pytest.mark.parametrize("amount", [-1, float("-inf"), float("nan")])
-async def test_invalid_acquire_preserves_capacity(amount: float) -> None:
-    limiter = AsyncLimiter(1)
-    await limiter.acquire()
-    with pytest.raises(ValueError):
-        await asyncio.wait_for(limiter.acquire(amount), timeout=0.1)
-    assert not limiter.has_capacity()
-
-
-async def test_acquire_zero_and_fractional_amounts() -> None:
-    limiter = AsyncLimiter(1)
-    with MockLoopTime():
-        await limiter.acquire(0)
-        assert limiter.has_capacity(1)
-        await limiter.acquire(0.5)
-        assert limiter.has_capacity(0.5)
-        assert not limiter.has_capacity(1)
+        await limiter.acquire(amount)
 
 
 async def acquire_task(limiter: AsyncLimiter) -> None:
@@ -119,6 +101,16 @@ class MockLoopTime:
 
     def __exit__(self, *_: object) -> None:
         self.patch.stop()
+
+
+async def test_acquire_zero_and_fractional_amounts() -> None:
+    limiter = AsyncLimiter(1)
+    with MockLoopTime():
+        await limiter.acquire(0)
+        assert limiter.has_capacity(1)
+        await limiter.acquire(0.5)
+        assert limiter.has_capacity(0.5)
+        assert not limiter.has_capacity(1)
 
 
 @pytest.mark.parametrize("task", [acquire_task, async_contextmanager_task])


### PR DESCRIPTION
`acquire()` currently accepts negative amounts, which decrease the bucket level and allow later acquisitions to exceed the configured burst capacity. Passing `float("nan")` instead leaves the acquisition waiting indefinitely because its capacity comparisons never succeed.

Validate the inclusive range from zero to `max_rate` with one comparison before changing state or creating waiters. Invalid amounts raise `ValueError`; zero and positive fractional acquisitions retain their existing behavior. The docstring describes the accepted range, and `changelog.d/760.feature.md` records the change.

The existing over-capacity test is now a parametrized boundary test covering `42`, `-1`, negative infinity, and NaN. The valid zero/fractional test follows the `MockLoopTime` helper it uses. The branch has been rebased onto current `main`.

Validation on Python 3.12:
- Full test suite: 14 passed; 100% statement and branch coverage for `leakybucket.py`.
- All applicable `prek` hooks passed, including Ruff formatting/linting and Pyright.
- `towncrier build --draft` renders the new entry under Features.
- `git diff --check` passed.
