### PR TITLE
chore: fix sdist packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ cache-keys = [
 
 [tool.hatch.build.targets.sdist]
 include = [
+    "src",
     "CHANGELOG.md",
     "tests",
 ]


### PR DESCRIPTION
Hatch's `include` directive _replaces_ the standard traversal, so
`src` must be listed explicitly.
