### PR TITLE
ci: simplify towncrier linting

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -164,16 +164,6 @@ jobs:
     - name: Check documentation
       run: |
         set -euo pipefail
-        for file in changelog.d/*; do
-          if [[ "$file" == changelog.d/towncrier_template.md ]]; then
-            continue
-          fi
-          if [[ ! "$file" =~ /[0-9]+\.(feature|bugfix|doc|removal|misc)(\.md)?$ ]]; then
-            echo -e "Not a valid towncrier fragment name: \e[1;33m{{.ITEM}}\e[0m"
-            echo 'Towncrier fragments consist of the GitHub issue number, a dot, and a type (feature, bugfix, doc, removal, misc), optionally followed by .md.'
-            exit 1
-          fi
-        done
         uv run towncrier build --draft
         cd docs || exit 1
         make spelling

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -172,22 +172,6 @@ tasks:
     cmds:
       - make spelling {{.CLI_ARGS}}
 
-  docs:checks:towncrier_fragments:
-    desc: Check changelog towncrier fragments
-    deps: ['util:check_uv']
-    method: none
-    sources:
-      - changelog.d/**
-      - exclude: changelog.d/towncrier_template.md
-    cmds:
-      - for: sources
-        cmd: |
-          if [[ ! "{{.ITEM}}" =~ /[0-9]+\.(feature|bugfix|doc|removal|misc)(\.md)?$ ]]; then
-            echo -e "Not a valid towncrier fragment name: \e[1;33m{{.ITEM}}\e[0m"
-            echo 'Towncrier fragments consist of the GitHub issue number, a dot, and a type (feature, bugfix, doc, removal, misc), optionally followed by .md.'
-            exit 1
-          fi
-
   docs:checks:towncrier:
     desc: Check changelog towncrier output()
     deps: ['util:check_uv']
@@ -202,7 +186,7 @@ tasks:
     desc: Run all documentation checks
     deps:
       - docs:checks:spelling
-      - docs:checks:towncrier_fragments
+      - docs:checks:towncrier
 
   docs:serve:
     aliases:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,3 +136,4 @@ title_format = "## {name} {version} ({project_date})"
 issue_format = "[#{issue}](https://github.com/mjpieters/aiolimiter/issues/{issue})"
 start_string = "<!-- Towncrier release notes start -->\n"
 underlines = ["", "", ""]
+ignore = []


### PR DESCRIPTION
`towncrier build --draft` will report on unrecognised files when `ignore` has been configured.
